### PR TITLE
Add type wrapper

### DIFF
--- a/prefect_alert/alert.py
+++ b/prefect_alert/alert.py
@@ -5,7 +5,7 @@ import prefect
 from prefect.blocks.notifications import AppriseNotificationBlock
 from prefect.utilities.asyncutils import is_async_fn
 
-from prefect_alert.utilities import _get_alert_message
+from prefect_alert.utilities import WrappedFlow, _get_alert_message
 
 
 def alert_on_failure(block_type: AppriseNotificationBlock, block_name: str):
@@ -60,7 +60,7 @@ def alert_on_failure(block_type: AppriseNotificationBlock, block_name: str):
                 else:
                     return state.result()
 
-            return wrapper
+            return WrappedFlow(wrapper)
         else:
 
             @wraps(flow)
@@ -79,6 +79,6 @@ def alert_on_failure(block_type: AppriseNotificationBlock, block_name: str):
                 else:
                     return state.result()
 
-            return wrapper
+            return WrappedFlow(wrapper)
 
     return decorator

--- a/prefect_alert/utilities.py
+++ b/prefect_alert/utilities.py
@@ -1,8 +1,8 @@
 """Contains useful functions for the decorator"""
+from functools import update_wrapper
 from uuid import UUID
 
 import prefect
-from prefect.client import get_client
 from prefect.settings import PREFECT_API_URL
 
 
@@ -27,3 +27,15 @@ def _get_alert_message(state: prefect.State, flow: prefect.Flow):
     flow_run_id = state.state_details.flow_run_id
     url = _get_flow_run_page_url(flow_run_id)
     return f"The flow {flow_name} fails. \n Summary: {str(state)}). \n Details: {url}"
+
+
+class WrappedFlow(prefect.Flow):
+    def __init__(self, wrapper):
+        if type(wrapper.__wrapped__) != prefect.Flow:
+            raise RuntimeError("This class can only wrap Prefect flows.")
+            
+        self.wrapper = wrapper
+        update_wrapper(self, wrapper.__wrapped__)
+
+    def __call__(self, *args, **kwargs):
+        return self.wrapper(*args, **kwargs)

--- a/tests/test_alert.py
+++ b/tests/test_alert.py
@@ -128,3 +128,20 @@ class TestAlertFlow:
             assert isinstance(state, prefect.client.schemas.State)
             block_type.load.assert_called_once_with(block_name)
             block_instance.notify.assert_called_once()
+
+    def test_is_flow_instance(self):
+        with patch("prefect.blocks.notifications.SlackWebhook") as SlackWebhookMock:
+            # the decorated flow should be an instance of prefect.Flow
+            # to ensure it works with deployments
+            @alert_on_failure(block_type=SlackWebhookMock, block_name="test")
+            @flow
+            def test_flow():
+                print("testing")
+
+            @alert_on_failure(block_type=SlackWebhookMock, block_name="test")
+            @flow
+            def test_async_flow():
+                print("testing async")
+
+            assert isinstance(test_flow, prefect.Flow)
+            assert isinstance(test_async_flow, prefect.Flow)


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to prefect-alert 🎉!

We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Run `pre-commit install && pre-commit run --all` for linting.

Happy engineering!
-->

<!-- Include an overview here -->
This pull request adds a wrapper class that helps this decorator do what it needs to do while still passing the type check that is currently causing it to fail when run in a deployment, as mentioned in https://github.com/PrefectHQ/prefect/issues/7338. The update in this PR makes the decorator usable without requiring changes to Prefect.


### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
-->

```
@alert_on_failure(block_type=SlackWebhook, block_name="test")
@flow
def test_flow():
    print("testing")

isinstance(test_flow, Flow)
---> returns True
```
### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [X] This pull request references any related issue
- [X] This pull request includes tests or only affects documentation.
- [ ] Summarized PR's changes in [CHANGELOG.md](https://github.com/khuyentran1401/prefect-alert/blob/main/CHANGELOG.md)
